### PR TITLE
fix positioning URP 15 / Unity 2023.1

### DIFF
--- a/Assets/Shaders/BotWGrass.shader
+++ b/Assets/Shaders/BotWGrass.shader
@@ -168,7 +168,7 @@ Shader "Custom/BotWGrass"
 			VertexOutput geomVert (VertexInput v)
             {
 				VertexOutput o; 
-				o.vertex = float4(TransformObjectToWorld(v.vertex), 1.0f);
+				o.vertex = v.vertex;
 				o.normal = TransformObjectToWorldNormal(v.normal);
 				o.tangent = v.tangent;
 				o.uv = TRANSFORM_TEX(v.uv, _GrassMap);


### PR DESCRIPTION
I have no idea of shaders and applied your very beautiful looking grass. 
Sadly in Unity 2023.1 / URP 15.0 the grass is rendered slightly besides the gameobject.
the further the gameobject is away from coordinates 0 0 0 the higher the offset is. 
Somehow my change fixes that

Before:
<img width="517" alt="image" src="https://github.com/daniel-ilett/shaders-botw-grass/assets/51869140/5c769498-e0ad-41a6-aadb-151f7f6eb532">


After:
<img width="485" alt="image" src="https://github.com/daniel-ilett/shaders-botw-grass/assets/51869140/3000ad58-3357-4407-9918-c88ef613f341">
