### PR TITLE
Fixing transform issues

### DIFF
--- a/Assets/Shaders/BotWGrass.shader
+++ b/Assets/Shaders/BotWGrass.shader
@@ -268,9 +268,9 @@ Shader "Custom/BotWGrass"
 			{
 				GeomData o;
 
-				o.pos = TransformObjectToHClip(pos + mul(transformationMatrix, offset));
+				o.pos = TransformWorldToHClip(pos + mul(transformationMatrix, offset));
 				o.uv = uv;
-				o.worldPos = TransformObjectToWorld(pos + mul(transformationMatrix, offset));
+				o.worldPos = TransformWorldToHClip(pos + mul(transformationMatrix, offset));
 
 				return o;
 			}


### PR DESCRIPTION
Hey, thank you for sharing this awesome grass shader. There is a small issue which breaks the transformations. There's an open pull request attempting to fix it already, however that breaks when the meshes are rotated. I believe this actually fixes all the issues. 

The problem was, that the geometry stage receives vertices in world space but then transforms them to clip space with TransformObjectToHClip.

After:
![image](https://github.com/daniel-ilett/shaders-botw-grass/assets/48481719/ae09e142-0faa-49f9-b3cf-4b79a72eacac)
